### PR TITLE
Fix keyboard shortcut settings

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,8 +6,8 @@
     <depends>com.intellij.modules.lang</depends>
     <actions>
         <action id="UniversalArgumentAction" class="UniversalArgumentAction" text="universal-argument" description="Repeat editor action">
-            <keyboard-shortcut first-keystroke="ctrl U" keymap="Mac OS X 10.5+"/>
-            <keyboard-shortcut first-keystroke="ctrl U" keymap="Mac OS X"/>
+            <keyboard-shortcut first-keystroke="ctrl U" keymap="Mac OS X 10.5+" replace-all="true"/>
+            <keyboard-shortcut first-keystroke="ctrl U" keymap="Mac OS X" replace-all="true"/>
             <keyboard-shortcut first-keystroke="ctrl U" keymap="$default"/>
         </action>
     </actions>


### PR DESCRIPTION
Without replace-all, "command U" would be also added to macOS keymap